### PR TITLE
Fix inconsistent font size for points display

### DIFF
--- a/app/src/main/java/com/workpointstracker/ui/wish/WishScreen.kt
+++ b/app/src/main/java/com/workpointstracker/ui/wish/WishScreen.kt
@@ -57,7 +57,7 @@ fun WishScreen(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = FormatUtils.formatPoints(totalPoints ?: 0.0),
-                    style = MaterialTheme.typography.headlineMedium,
+                    style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
Change WishScreen points display from headlineMedium to headlineSmall to match HomeScreen for visual consistency across the app.

Fixes #1